### PR TITLE
Delay fetch of finalized Workout following completion

### DIFF
--- a/api/src/controllers/workouts.js
+++ b/api/src/controllers/workouts.js
@@ -97,8 +97,8 @@ router.put('/:id', (req, res) => {
         }
         else {
             return Promise.all([
-                database.set(userId, 'workouts', workouts),
-                database.put(userId, workout)
+                database.set(userId, 'workouts', workouts), // update the primary table to remove the workout
+                database.put(userId, workout) // insert the workout into history
             ]).then(() => { return workouts });
         }
     })

--- a/web/src/components/workouts/Workout.js
+++ b/web/src/components/workouts/Workout.js
@@ -184,8 +184,15 @@ class Workout extends Component {
                 this.props.showSnackbar('Error completing Workout \'' + workout.routine.name + '\'.');
                 reject(error);
             })
-            .then(() => this.fetchWorkout());
-        })
+            .then(() => {
+                // wait a little bit before trying to fetch the completed workout record from the backend.
+                // the api operation that moves the completed workout is async but there's still lag somewhere
+                // in a spot i can't control
+                this.setState({ api: { ...this.state.api, isExecuting: true}}, () => {
+                    setTimeout(() => this.fetchWorkout(), 1000);
+                })
+            });
+        });
     }
 
     handleWorkoutStart = (workout) => {


### PR DESCRIPTION
Closes #218 

The backend is asynchronous but manages the flow such as not to resolve the api call until the database operations are complete, however the following fetch sometimes fails with a 404.  I suspect this has something to do with database consistency, but am not sure.